### PR TITLE
Bump clojupyter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.24
+- Upgrade `dev.nubank/clojupyter` to verion 0.3.3-SNAPSHOT
+
 ## 0.1.23
 - Use `dev.nubank/clojupyter` fork on version `0.3.2-fix1`
 - Remove pinned dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.1.23"
+(defproject nubank/lein-jupyter "0.1.24"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}
@@ -8,7 +8,7 @@
 
   ;; TODO: Go back to clojupyter upstream after this PR is merged and a new release
   ;; is made: https://github.com/clojupyter/clojupyter/pull/135
-  :dependencies [[dev.nubank/clojupyter "0.3.2-fix1"]
+  :dependencies [[dev.nubank/clojupyter "0.3.3-SNAPSHOT"]
                  [org.apache.commons/commons-exec "1.3"]]
   :resource-paths ["resources"]
   :eval-in-leiningen true)

--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -7,7 +7,7 @@
 
 (defn run-kernel [project argv]
   (let [curr-deps (or (:dependencies project) [])
-        new-deps  (conj curr-deps ['dev.nubank/clojupyter "0.3.2-fix1"])
+        new-deps  (conj curr-deps ['dev.nubank/clojupyter "0.3.3-SNAPSHOT"])
         prj       (assoc project :dependencies new-deps)]
     (eval/eval-in-project prj
                           (conj (list argv) `clojupyter.kernel.core/-main)


### PR DESCRIPTION
Bump `nubank.dev/clojupyter` to version 0.3.3-SNAPSHOT:
 - Add support to run clojupyter on M1 Mac

### Related
- https://github.com/nubank/clojupyter/pull/2