### PR TITLE
Update clojupyter 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.24-NUBANK-3
+- Bump clojupyter version to 0.3.3;
+- Change clojupyter dependency back to the original repo instead of nubank's fork;
+
 ## 0.1.24-NUBANK
 - Upgrade `dev.nubank/clojupyter` to verion 0.3.3-alpha2-NUBANK
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.1.24-NUBANK"
+(defproject nubank/lein-jupyter "0.1.24-NUBANK-3"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
   :repositories [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
                  ["clojars" {:url "https://clojars.org/repo/"}]]
 
-  ;; TODO: Go back to clojupyter upstream after this PR is merged and a new release
-  ;; is made: https://github.com/clojupyter/clojupyter/pull/135
-  :dependencies [[dev.nubank/clojupyter "0.3.3-alpha2-NUBANK"]
+  :dependencies [[clojupyter "0.3.3"]                           ;; this dependency needs to be
+                                                                ;; updated in leiningen.jupyter.kernel
+                                                                ;; manually.
                  [org.apache.commons/commons-exec "1.3"]]
   :resource-paths ["resources"]
   :eval-in-leiningen true)

--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -7,7 +7,7 @@
 
 (defn run-kernel [project argv]
   (let [curr-deps (or (:dependencies project) [])
-        new-deps  (conj curr-deps ['dev.nubank/clojupyter "0.3.3-SNAPSHOT"])
+        new-deps  (conj curr-deps ['clojupyter "0.3.3"])
         prj       (assoc project :dependencies new-deps)]
     (eval/eval-in-project prj
                           (conj (list argv) `clojupyter.kernel.core/-main)


### PR DESCRIPTION
# Context
- Bump clojupyter version to 0.3.3
- Change clojupyter to the original repo instead of nubank's fork; 