### PR TITLE
Add release automation and PR checks

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,46 @@
+name: Clojure CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-using-java-11:
+    name: 'Test using Java 11'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test
+
+  test-using-java-17:
+    name: 'Test using Java 17'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 17
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  test-using-java-11:
+    name: 'Test using Java 11'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test
+
+  test-using-java-17:
+    name: 'Test using Java 17'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 17
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test
+
+  release:
+    name: 'Publish on Clojars'
+    runs-on: ubuntu-latest
+    needs: [test-using-java-17, test-using-java-11]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Publish on Clojars
+      run: lein deploy publish
+      env:
+          CLOJARS_USERNAME: eng-prod-nubank
+          CLOJARS_PASSWD: ${{ secrets.CLOJARS_DEPLOY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ pom.xml.asc
 /.idea/
 lein-jupyter.iml
 todo.md
+.calva/
+.lsp/.cache
+.clj-kondo/.cache

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+# Releasing
+
+Anybody with write access to this repository can release a new version and deploy it to Clojars. To do this, first make sure your local master is sync'd with master on github:
+
+```bash
+git checkout master
+git pull
+```
+
+Now run this command:
+```
+./release.sh
+```
+
+The `release.sh` script creates a git tag with the project's current version and pushes it
+to github. This will trigger a GithubAction that tests and uploads JAR files to
+Clojars.
+
+The release process makes use of [Clojars Deploy tokens](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens)

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}
 
-  :repositories [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
-                 ["clojars" {:url "https://clojars.org/repo/"}]]
+  :repositories [["publish" {:url "https://clojars.org/repo"
+                             :sign-releases false}]]
 
   :dependencies [[clojupyter "0.3.6"]                           ;; this dependency needs to be
                                                                 ;; updated in leiningen.jupyter.kernel

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+project_version="$(lein project-version | tail -n1)"
+
+git tag "$project_version"
+git push origin "$project_version"


### PR DESCRIPTION
## Context
The process of releasing a new version is manual and it's not well documented.
## Changes
- Add `release.sh` script that will:
  - Create a new git tag with the project's current version and push it.
  - Use the new `release` Github action that will run the tests and upload a new version to Clojars.
- Add `RELEASING.md` with the instructions for releasing a new version.
- Add Github workflow running tests on PRs and master's pushes.