### PR TITLE
Add username/password env vars to Clojars publish repository

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,8 @@
   :license {:name "MIT License"}
 
   :repositories [["publish" {:url "https://clojars.org/repo"
+                             :username :env/clojars_username
+                             :password :env/clojars_passwd
                              :sign-releases false}]]
 
   :dependencies [[clojupyter "0.3.6"]                           ;; this dependency needs to be


### PR DESCRIPTION
## Context
We're missing username/password in Clojars publish respository definition in `project.clj`. Because of that, we are unable to release a new version.
## Changes
Add username/password env vars to Clojars publish repository