### PR TITLE
Add support for nbclassic

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.2.24-NUBANK-4"
+(defproject nubank/lein-jupyter "0.2.24-NUBANK-5"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}

--- a/src/leiningen/jupyter.clj
+++ b/src/leiningen/jupyter.clj
@@ -1,26 +1,33 @@
 (ns leiningen.jupyter
-  (:require [leiningen.core.main]
-            [leiningen.jupyter.extension :refer [install-and-enable-extension]]
-            [leiningen.jupyter.kernel :refer [install-kernel
-                                              run-kernel
-                                              kernel-installed?]]
-            [leiningen.jupyter.params :as params])
+  (:require
+   [leiningen.core.main :as leiningen.main]
+   [leiningen.jupyter.extension :refer [install-and-enable-extension]]
+   [leiningen.jupyter.kernel :refer [install-kernel kernel-installed?
+                                     run-kernel]]
+   [leiningen.jupyter.params :as params]
+   [leiningen.jupyter.utils :as utils])
 
-  (:import [org.apache.commons.exec CommandLine
-                                    DefaultExecutor
-                                    PumpStreamHandler]))
+  (:import
+   [org.apache.commons.exec CommandLine DefaultExecutor PumpStreamHandler]))
 
 (defn get-jupyter-command [jupyter sub-command jupyter-arguments]
   (let [all-arguments (into [sub-command] jupyter-arguments)
         add-args #(.addArgument %1 %2)]
       (reduce add-args (new CommandLine jupyter) all-arguments)))
 
+(defn ^:private jupyter-start-sub-command
+  [jupyter-exe]
+  (let [jupyter-version (utils/jupyterlab-version jupyter-exe)]
+    (if (= 4 jupyter-version)
+      "nbclassic"
+      "notebook")))
 
 (defn start-jupyter-notebook [project environ jupyter-arguments]
   (let [executor (new DefaultExecutor)
         stream-handler (new PumpStreamHandler System/out System/err System/in)
-        jupyter (params/jupyer-executable project)
-        cmd (get-jupyter-command jupyter "notebook" jupyter-arguments)]
+        jupyter-exe (params/jupyer-executable project)
+        sub-command (jupyter-start-sub-command jupyter-exe)
+        cmd (get-jupyter-command jupyter-exe sub-command jupyter-arguments)]
     (.setStreamHandler executor stream-handler)
     (.execute executor cmd environ)))
 
@@ -37,27 +44,36 @@
     (into env new-envs)))
 
 (defn notebook [project lein-wd & args]
-  (if (not (kernel-installed?))
-    (leiningen.core.main/warn "It seems you have not installed the lein-jupyter kernel.  "
-                              "You should run `lein jupyter install-kernel`."))
+  (when (not (kernel-installed?))
+    (leiningen.main/abort "It seems you have not installed the lein-jupyter kernel.  "
+                          "You should run `lein jupyter install-kernel`."))
   (let [new-env {"LEIN_WORKING_DIRECTORY" lein-wd}
         env (add-to-system-environment new-env)]
     (start-jupyter-notebook project env args)))
 
 (defn lab [project lein-wd & args]
-  (if (not (kernel-installed?))
-    (leiningen.core.main/warn "It seems you have not installed the lein-jupyter kernel.  "
-                              "You should run `lein jupyter install-kernel`."))
+  (when (not (kernel-installed?))
+    (leiningen.main/abort "It seems you have not installed the lein-jupyter kernel.  "
+                          "You should run `lein jupyter install-kernel`."))
   (let [new-env {"LEIN_WORKING_DIRECTORY" lein-wd}
         env (add-to-system-environment new-env)]
     (start-jupyter-lab project env args)))
 
+(defn install-kernel-and-extensions
+  [project args]
+  (or (apply install-kernel args)
+      (leiningen.main/abort "Couldn't install kernel"))
+  (or (install-and-enable-extension project)
+      (leiningen.main/abort "Couln't install extensions")))
 
 (defn jupyter
   "Leiningen's jupyter integration.
 
   To use this leiningen pluging, you need to have jupyter notebook
   installed.  See http://jupyter.org/ for instructions.
+
+  ATENTION: If you are using jupyterlab > 4.0.0 you will need to install
+  `nbclassic`: https://nbclassic.readthedocs.io/en/latest/nbclassic.html#installation
 
   Once you have jupyter notebook installed, you will need to run the
   `lein jupyter install-kernel` command once.  This will install the
@@ -87,9 +103,7 @@
   ([project sub-command & args]
    (let [cwd (-> (java.io.File. ".") .getAbsolutePath)]
      (case sub-command
-       "install-kernel" (do
-                          (apply install-kernel args)
-                          (install-and-enable-extension project))
+       "install-kernel" (install-kernel-and-extensions project args)
        "uninstall-kernel" (leiningen.core.main/info (str "Not yet implemented.  You can use "
                                                          "'jupyter kernelspec uninstall lein-clojure' "
                                                           "to uninstall the kernel manually."))
@@ -97,7 +111,7 @@
        "lab" (apply lab project cwd args)
        "kernel" (apply run-kernel project args)   ;; hidden kernel
        (leiningen.core.main/info (:doc (meta #'jupyter))))))
-  ([project]
+  ([_project]
    (leiningen.core.main/info (:doc (meta #'jupyter)))))
 
 

--- a/src/leiningen/jupyter.clj
+++ b/src/leiningen/jupyter.clj
@@ -18,7 +18,7 @@
 (defn ^:private jupyter-start-sub-command
   [jupyter-exe]
   (let [jupyter-version (utils/jupyterlab-version jupyter-exe)]
-    (if (= 4 jupyter-version)
+    (if (>= 4 jupyter-version)
       "nbclassic"
       "notebook")))
 
@@ -44,7 +44,7 @@
     (into env new-envs)))
 
 (defn notebook [project lein-wd & args]
-  (when (not (kernel-installed?))
+  (when-not (kernel-installed?)
     (leiningen.main/abort "It seems you have not installed the lein-jupyter kernel.  "
                           "You should run `lein jupyter install-kernel`."))
   (let [new-env {"LEIN_WORKING_DIRECTORY" lein-wd}
@@ -52,7 +52,7 @@
     (start-jupyter-notebook project env args)))
 
 (defn lab [project lein-wd & args]
-  (when (not (kernel-installed?))
+  (when-not (kernel-installed?)
     (leiningen.main/abort "It seems you have not installed the lein-jupyter kernel.  "
                           "You should run `lein jupyter install-kernel`."))
   (let [new-env {"LEIN_WORKING_DIRECTORY" lein-wd}

--- a/src/leiningen/jupyter.clj
+++ b/src/leiningen/jupyter.clj
@@ -18,7 +18,7 @@
 (defn ^:private jupyter-start-sub-command
   [jupyter-exe]
   (let [jupyter-version (utils/jupyterlab-version jupyter-exe)]
-    (if (>= 4 jupyter-version)
+    (if (>= jupyter-version 4)
       "nbclassic"
       "notebook")))
 

--- a/src/leiningen/jupyter/extension.clj
+++ b/src/leiningen/jupyter/extension.clj
@@ -1,9 +1,13 @@
 (ns leiningen.jupyter.extension
-  (:import [java.nio.file Files]
-           [java.nio.file.attribute FileAttribute])
-  (:require [clojure.java.io :as io]
-            [clojure.java.shell :refer [sh]]
-            [leiningen.jupyter.params :as params]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :refer [sh]]
+   [leiningen.core.main :as leiningen.main]
+   [leiningen.jupyter.params :as params]
+   [leiningen.jupyter.utils :as utils])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
 
 
 (def resources
@@ -19,33 +23,53 @@
   (io/make-parents dest)
   (spit dest content))
 
-
 (defn copy-resource-dir-in-tmp-dir [name]
   (let [root-tmp-dir (.toFile (Files/createTempDirectory "lein-jupyter" (into-array FileAttribute [])))
         tmp-dir (io/file root-tmp-dir name)]
     (doall (map #(move-resource (io/file tmp-dir (.getName %))  (get-resource-by-name %)) resources))
     tmp-dir))
 
+(defmulti enable-extension* (fn [major-version & _args] major-version))
+
+(defmethod enable-extension* 3
+  [_ jupyter-ex extension-main]
+  (sh jupyter-ex "nbextension" "enable" extension-main "--user"))
+
+(defmethod enable-extension* 4
+  [_ _jupyter-ex extension-main]
+  (sh "jupyter-nbclassic-extension" "enable" extension-main "--user"))
+
 (defn enable-extension
   "enable the lein-jupyter-parinfer extension the user space"
-  [jupyter]
-  (let [enable-out (sh jupyter "nbextension" "enable" "lein-jupyter-parinfer/index" "--user")]
+  [jupyter-version jupyter-exe]
+  (let [enable-out (enable-extension* jupyter-version jupyter-exe "lein-jupyter-parinfer/index")]
     (if (not= 0 (:exit enable-out))
-      (leiningen.core.main/warn "Did not succeed to enable lein-jupyter-parinfer extension"
-                                (:err enable-out))
+      (leiningen.main/warn "Did not succeed to enable lein-jupyter-parinfer extension"
+                           (:err enable-out))
       true)))
+
+(defmulti install-extension* (fn [major-version & _args] major-version))
+
+(defmethod install-extension* 3
+  [_ jupyter-exe extension-dir]
+  (sh jupyter-exe "nbextension" "install" extension-dir "--user"))
+
+(defmethod install-extension* 4
+  [_ _jupyter-exe extension-dir]
+  (sh "jupyter-nbclassic-extension" "install" extension-dir "--user"))
 
 (defn install-extension
   "Instal the lein-jupyter-parinfer extension the user space"
-  [jupyter]
+  [jupyter-version jupyter-exe]
   (let [extension-dir (copy-resource-dir-in-tmp-dir "lein-jupyter-parinfer")
-        install-out (sh jupyter "nbextension" "install" (.getCanonicalPath extension-dir) "--user")]
+        install-out (install-extension* jupyter-version jupyter-exe (.getCanonicalPath extension-dir))]
     (if (not= 0 (:exit install-out))
-      (leiningen.core.main/warn "Did not succeed to install lein-jupyter-parinfer extension"
-                                (:err install-out))
+      (leiningen.main/warn "Did not succeed to install lein-jupyter-parinfer extension"
+                           (:err install-out))
       true)))
 
 (defn install-and-enable-extension [project]
-  (let [jupyter (params/jupyer-executable project)]
-    (and (install-extension jupyter)
-         (enable-extension jupyter))))
+  (let [jupyter-exe (params/jupyer-executable project)
+        jupyter-version (utils/jupyterlab-version jupyter-exe)]
+    (and (install-extension jupyter-version jupyter-exe)
+         (enable-extension jupyter-version jupyter-exe))))

--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clojure.string :refer [includes? lower-case]]
             [leiningen.core.eval :as eval]
-            [leiningen.core.main]))
+            [leiningen.core.main :as leiningen.main]))
 
 (defn run-kernel [project argv]
   (let [curr-deps (or (:dependencies project) [])
@@ -61,12 +61,18 @@ the current supported systems are Linux Mac and Windows (In that order).")
 
   The kernel will be installed at <location>/lein-clojure."
   ([location]
-   (-> location io/as-file create-kernel)
-   (leiningen.core.main/info "kernel successfully installed at " (str location)))
+   (try
+     (-> location io/as-file create-kernel)
+     (leiningen.main/info "kernel successfully installed at " (str location))
+     true
+     (catch Exception e
+       (leiningen.main/warn "error installing the clojupyter kernel at " (str location)
+                            (.getMessage e))
+       false)))
   ([]
    (let [os (get-os)]
      (if (nil? os)
-       (leiningen.core.main/warn architecture-not-yet-supported)
+       (leiningen.main/warn architecture-not-yet-supported)
        (-> os (get-platform-specific-kernel-dir (System/getenv)) install-kernel)))))
 
 (defn kernel-installed?

--- a/src/leiningen/jupyter/utils.clj
+++ b/src/leiningen/jupyter/utils.clj
@@ -1,0 +1,48 @@
+(ns leiningen.jupyter.utils
+  (:require
+   [clojure.java.shell :refer [sh]]
+   [clojure.string :as string]))
+
+(defn ^:private run-jupyter-versions-cmd
+  [jupyter-exec]
+  (let [{:keys [exit out]} (sh jupyter-exec "--version")]
+    (when (= 0 exit)
+      out)))
+
+(defn jupyter-versions
+  "Run the jupyter --version in a shell, and return a map with
+  the result.
+
+  E.g:
+  {\"nbformat\"       \"5.9.2\"
+   \"jupyter_core\"   \"5.3.0\"
+   \"notebook\"       \"not installed\"
+   \"jupyterlab\"     \"4.0.5\"
+   \"jupyter_server\" \"2.7.3\"}"
+  [jupyter-exec]
+  (->> (run-jupyter-versions-cmd jupyter-exec)
+       (#(clojure.string/split % #"\n"))
+       (drop 1)                                   ; Selected Jupyter core packages...
+       (map #(clojure.string/split % #"\s+:\s+")) ; jupyterlab       : 4.0.5
+       flatten
+       (apply hash-map)))
+
+(defn to-int
+  [s]
+  (try
+    (Integer/parseInt s)
+    (catch Exception _ nil)))
+
+(defn major-version
+  [version]
+  (some-> version
+          (string/split #"\.")
+          first
+          to-int))
+
+(defn jupyterlab-version
+  [jupyter-exe]
+  (-> jupyter-exe
+      jupyter-versions
+      (get "jupyterlab")
+      major-version))

--- a/test/test_leiningen/extension_test.clj
+++ b/test/test_leiningen/extension_test.clj
@@ -1,0 +1,19 @@
+(ns test-leiningen.extension-test 
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [leiningen.jupyter.extension :as extension]))
+
+(deftest nbextension-cmd-test
+  (testing "Major version 3 and before should use jupyter jupyter nbextension"
+    (is (= ["jupyter" "nbextension" "my-command" "--arg" "xpto"]
+           (extension/nbextension-cmd 3 "jupyter" "my-command" "--arg" "xpto")))
+
+    (is (= ["jupyter" "nbextension" "my-command" "--arg" "xpto"]
+           (extension/nbextension-cmd 2 "jupyter" "my-command" "--arg" "xpto"))))
+
+  (testing "Major version 4 and beyond should use jupyter nb-classic-extension without calling jupyter"
+    (is (= ["jupyter-nbclassic-extension" "my-command" "--arg" "xpto"]
+           (extension/nbextension-cmd 4 "jupyter" "my-command" "--arg" "xpto")))
+
+    (is (= ["jupyter-nbclassic-extension" "my-command" "--arg" "xpto"]
+           (extension/nbextension-cmd 5 "jupyter" "my-command" "--arg" "xpto")))))

--- a/test/test_leiningen/extension_test.clj
+++ b/test/test_leiningen/extension_test.clj
@@ -3,6 +3,13 @@
    [clojure.test :refer [deftest is testing]]
    [leiningen.jupyter.extension :as extension]))
 
+(deftest extract-resource-test
+    (testing "the copy of the resources"
+      (let [resource "lein-jupyter-parinfer"
+            ret (extension/copy-resource-dir-in-tmp-dir resource)]
+        (is (= (.getName ret) "lein-jupyter-parinfer"))
+        (is (= (count (.listFiles ret)) 4)))))
+
 (deftest nbextension-cmd-test
   (testing "Major version 3 and before should use jupyter jupyter nbextension"
     (is (= ["jupyter" "nbextension" "my-command" "--arg" "xpto"]

--- a/test/test_leiningen/util_test.clj
+++ b/test/test_leiningen/util_test.clj
@@ -1,11 +1,30 @@
 (ns test-leiningen.util-test
-  (:require [clojure.test :refer :all]
-            [leiningen.jupyter.extension :as util]
-            [clojure.java.io :as io]))
+  (:require
+   [clojure.java.shell :refer [sh]]
+   [clojure.test :refer [deftest is]]
+   [leiningen.jupyter.utils :as utils]))
 
-(deftest extract-resource-test
-    (testing "the copy of the resources"
-      (let [resource "lein-jupyter-parinfer"
-            ret (util/copy-resource-dir-in-tmp-dir resource)]
-        (is (= (.getName ret) "lein-jupyter-parinfer"))
-        (is (= (count (.listFiles ret)) 4)))))
+(defn mock-sh
+  [output]
+  (fn [& _args] output))
+
+(def version-output
+  "Selected Jupyter core packages...\nIPython          : 8.12.2\nipykernel        : 6.25.0\njupyterlab       : 3.6.3\nnbclient         : 0.5.13\nnotebook         : 6.5.2")
+
+(deftest jupyter-versions-test
+  (with-redefs [sh (mock-sh {:exit 0 :out version-output})]
+    (is (= {"IPython"    "8.12.2"
+            "ipykernel"  "6.25.0"
+            "jupyterlab" "3.6.3"
+            "nbclient"   "0.5.13"
+            "notebook"   "6.5.2"}
+           (utils/jupyter-versions "jupyter-test")))))
+
+(deftest major-version-test
+  (is (= 3
+         (utils/major-version "3.6.2"))))
+
+(deftest jupyterlab-version-test
+  (with-redefs [sh (mock-sh {:exit 0 :out version-output})]
+    (is (= 3
+           (utils/jupyterlab-version "jupyter-test")))))


### PR DESCRIPTION
### Context

With the release of [jupyterlab 4](https://blog.jupyter.org/jupyterlab-4-0-is-here-388d05e03442), the Notebook 7 became the default, but frontend extensions [will not work anymore](https://jupyter-notebook.readthedocs.io/en/latest/migrating/frontend-extensions.html). 

The solution may be to migrate the extensions to [jupyter labextension](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#id10). Meanwhile, we can install the [nbclassic](https://github.com/jupyter/nbclassic) to keep supporting our current `parinfer` extension.

### Changes
- Add a parser of Jupyter versions (`jupyter --version`) to be able to check the jupyterlab installation;
- Add support to install extensions using `nbclassic` when clojupyter >= `4.0.0`;
- Execute the `nbclassic` subcommand instead `notebook` when clojupyter >= `4.0.0`;
- Stop the execution and return an exit code different than 0 when: 
   - cannot install the kernel;
   - cannot install the paredit extension;
   - the notebook is executed without an installed clojupyter kernel;