### PR TITLE
Avoid NPE when jupyterlab is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.24-NUBANK-6
+- Fix NPE when getting the jupyterlab version for nbclassic;
+
+## 0.2.24-NUBANK-5
+- Add support for nbclassic when clojupyter >= 4.0.0
+- Abort the execution when cannot install kernel and extensions;
+
 ## 0.2.24-NUBANK-4
 - Bump clojupyter version to 0.3.6;
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.2.24-NUBANK-5"
+(defproject nubank/lein-jupyter "0.2.24-NUBANK-6"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}

--- a/src/leiningen/jupyter.clj
+++ b/src/leiningen/jupyter.clj
@@ -17,8 +17,8 @@
 
 (defn ^:private jupyter-start-sub-command
   [jupyter-exe]
-  (let [jupyter-version (utils/jupyterlab-version jupyter-exe)]
-    (if (>= jupyter-version 4)
+  (let [jupyter-version (utils/maybe-jupyterlab-version jupyter-exe)]
+    (if (and jupyter-version (>= jupyter-version 4))
       "nbclassic"
       "notebook")))
 

--- a/src/leiningen/jupyter/utils.clj
+++ b/src/leiningen/jupyter/utils.clj
@@ -1,7 +1,8 @@
 (ns leiningen.jupyter.utils
   (:require
    [clojure.java.shell :refer [sh]]
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   [leiningen.core.main :as leiningen.main]))
 
 (defn ^:private run-jupyter-versions-cmd
   [jupyter-exec]
@@ -40,9 +41,10 @@
           first
           to-int))
 
-(defn jupyterlab-version
+(defn maybe-jupyterlab-version
   [jupyter-exe]
-  (-> jupyter-exe
-      jupyter-versions
-      (get "jupyterlab")
-      major-version))
+  (let [jupyterlab-version (-> jupyter-exe jupyter-versions (get "jupyterlab"))
+        major-version (major-version jupyterlab-version)]
+    (when-not major-version
+      (leiningen.main/warn "Did not succeed to get jupyterlab version" jupyterlab-version))
+   major-version))

--- a/test/test_leiningen/util_test.clj
+++ b/test/test_leiningen/util_test.clj
@@ -22,9 +22,13 @@
 
 (deftest major-version-test
   (is (= 3
-         (utils/major-version "3.6.2"))))
+         (utils/major-version "3.6.2")))
+  (is (= nil
+         (utils/major-version "not installed")))
+  (is (= nil
+         (utils/major-version "x.y.z"))))
 
 (deftest jupyterlab-version-test
   (with-redefs [sh (mock-sh {:exit 0 :out version-output})]
     (is (= 3
-           (utils/jupyterlab-version "jupyter-test")))))
+           (utils/maybe-jupyterlab-version "jupyter-test")))))


### PR DESCRIPTION
Avoid NPE when jupyterlab isn't installed.

```
kernel successfully installed at  /Users/denis.piazentin/Library/Jupyter/kernels
java.lang.NullPointerException: null
 at clojure.lang.Numbers.ops (Numbers.java:1095)
    clojure.lang.Numbers.gte (Numbers.java:265)
    clojure.lang.Numbers.gte (Numbers.java:3991)
    leiningen.jupyter.extension$nbextension_cmd.invokeStatic (extension.clj:34)
    leiningen.jupyter.extension$nbextension_cmd.doInvoke (extension.clj:32)
    clojure.lang.RestFn.invoke (RestFn.java:490)
    leiningen.jupyter.extension$install_extension_sh.invokeStatic (extension.clj:53)
    leiningen.jupyter.extension$install_extension_sh.invoke (extension.clj:51)
    leiningen.jupyter.extension$install_extension.invokeStatic (extension.clj:59)
    leiningen.jupyter.extension$install_extension.invoke (extension.clj:55)
    leiningen.jupyter.extension$install_and_enable_extension.invokeStatic (extension.clj:68)
    leiningen.jupyter.extension$install_and_enable_extension.invoke (extension.clj:65)
    leiningen.jupyter$install_kernel_and_extensions.invokeStatic (jupyter.clj:66)
    leiningen.jupyter$install_kernel_and_extensions.invoke (jupyter.clj:62)
    leiningen.jupyter$jupyter.invokeStatic (jupyter.clj:106)
    leiningen.jupyter$jupyter.doInvoke (jupyter.clj:69)
```

Jupyter version:
```
jupyter --version
Selected Jupyter core packages...
IPython          : 8.16.1
ipykernel        : 6.25.2
ipywidgets       : not installed
jupyter_client   : 8.4.0
jupyter_core     : 5.4.0
jupyter_server   : 2.8.0
jupyterlab       : not installed
nbclient         : 0.8.0
nbconvert        : 7.9.2
nbformat         : 5.9.2
notebook         : not installed
qtconsole        : not installed
traitlets        : 5.11.2
```