### PR TITLE
Bump clojupyter verstion to 0.4.332

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -7,53 +7,24 @@ on:
     branches: [ master ]
 
 jobs:
-  test-using-java-11:
-    name: 'Test using Java 11'
+  test-using-java:
+    strategy:
+      matrix:
+        java-version: [ '11', '17', '21' ]
+    name: Test using Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: ${{ matrix.java-version }}
 
-    - name: Print java version
-      run: java -version
-
-    - name: Install dependencies
-      run: lein deps
-
-    - name: Run clj tests
-      run: lein test
-
-  test-using-java-17:
-    name: 'Test using Java 17'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-java@v1
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.2
       with:
-        java-version: 17
-
-    - name: Print java version
-      run: java -version
-
-    - name: Install dependencies
-      run: lein deps
-
-    - name: Run clj tests
-      run: lein test
-
-  test-using-java-21:
-    name: 'Test using Java 21'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 21
+        lein: 2.11.2
 
     - name: Print java version
       run: java -version

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -44,3 +44,22 @@ jobs:
 
     - name: Run clj tests
       run: lein test
+
+  test-using-java-21:
+    name: 'Test using Java 21'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 21
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,53 +6,24 @@ on:
     - '*'
 
 jobs:
-  test-using-java-11:
-    name: 'Test using Java 11'
+  test-using-java:
+    strategy:
+      matrix:
+        java-version: [ '11', '17', '21' ]
+    name: Test using Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: ${{ matrix.java-version }}
 
-    - name: Print java version
-      run: java -version
-
-    - name: Install dependencies
-      run: lein deps
-
-    - name: Run clj tests
-      run: lein test
-
-  test-using-java-17:
-    name: 'Test using Java 17'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-java@v1
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.2
       with:
-        java-version: 17
-
-    - name: Print java version
-      run: java -version
-
-    - name: Install dependencies
-      run: lein deps
-
-    - name: Run clj tests
-      run: lein test
-
-  test-using-java-21:
-    name: 'Test using Java 21'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 21
+        lein: 2.11.2
 
     - name: Print java version
       run: java -version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,25 @@ jobs:
     - name: Run clj tests
       run: lein test
 
+  test-using-java-21:
+    name: 'Test using Java 21'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 21
+
+    - name: Print java version
+      run: java -version
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run clj tests
+      run: lein test
+
   release:
     name: 'Publish on Clojars'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.24-NUBANK-7
+- Bump clojupyter version to 0.4.332;
+
 ## 0.2.24-NUBANK-6
 - Fix NPE when getting the jupyterlab version for nbclassic;
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.2.24-NUBANK-6"
+(defproject nubank/lein-jupyter "0.2.24-NUBANK-7"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}
@@ -8,7 +8,7 @@
                              :password :env/clojars_passwd
                              :sign-releases false}]]
 
-  :dependencies [[clojupyter "0.3.6"]                           ;; this dependency needs to be
+  :dependencies [[clojupyter "0.4.332"]                         ;; this dependency needs to be
                                                                 ;; updated in leiningen.jupyter.kernel
                                                                 ;; manually.
                  [org.apache.commons/commons-exec "1.3"]]

--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -1,7 +1,7 @@
 (ns leiningen.jupyter.kernel
   (:require [cheshire.core :as cheshire]
             [clojure.java.io :as io]
-            [clojure.string :refer [includes? lower-case]]
+            [clojure.string :refer [includes?]]
             [leiningen.core.eval :as eval]
             [leiningen.core.main :as leiningen.main]))
 

--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -7,7 +7,7 @@
 
 (defn run-kernel [project argv]
   (let [curr-deps (or (:dependencies project) [])
-        new-deps  (conj curr-deps ['clojupyter "0.3.6"])
+        new-deps  (conj curr-deps ['clojupyter "0.4.332"])
         prj       (assoc project :dependencies new-deps)]
     (eval/eval-in-project prj
                           (conj (list argv) `clojupyter.kernel.core/-main)

--- a/test/test_leiningen/jupyter_test.clj
+++ b/test/test_leiningen/jupyter_test.clj
@@ -1,5 +1,5 @@
 (ns test-leiningen.jupyter-test
-    (:require [clojure.test :refer :all]
+    (:require [clojure.test :refer [deftest is testing]]
               [clojure.java.io :as io]
               [leiningen.jupyter :as jupyter]
               [leiningen.jupyter.kernel :as kernel]))


### PR DESCRIPTION
### Changelog
- Bump Clojupyter version to 0.4.332
- Fix Java test workflows, adding Java 21 check