### PR TITLE
Fix release workflow depending on old test workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,14 @@ jobs:
   release:
     name: 'Publish on Clojars'
     runs-on: ubuntu-latest
-    needs: [test-using-java-17, test-using-java-11]
+    needs: [test-using-java]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.2
+      with:
+        lein: 2.11.2
 
     - name: Install dependencies
       run: lein deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.24-NUBANK-8
+- Fix release workflow depending on old test workflows;
+
 ## 0.2.24-NUBANK-7
 - Bump clojupyter version to 0.4.332;
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lein-jupyter "0.2.24-NUBANK-7"
+(defproject nubank/lein-jupyter "0.2.24-NUBANK-8"
   :description "Leiningen plugin for jupyter notebook."
   :url "https://github.com/nubank/lein-jupyter"
   :license {:name "MIT License"}


### PR DESCRIPTION
Fix release workflow depending on old test workflows instead of the new added in https://github.com/nubank/lein-jupyter/pull/14